### PR TITLE
Release/2.0.0

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,6 +20,6 @@ jobs:
 
     - name: Publish release
       env:
-        GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN_CI }}
         COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TOKEN_CI }}
       run: bundle exec fastlane publish_release

--- a/ADNavigationBarExtension.podspec
+++ b/ADNavigationBarExtension.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'ADNavigationBarExtension'
-  s.version          = '1.0.4'
+  s.version          = '2.0.0'
   s.author           = 'Fabernovel Technologies'
   s.homepage         = 'https://fabernovel.com/'
   s.summary          = 'ADNavigationBarExtension is a UI library written in Swift to show and hide an extension to your UINavigationBar'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [Unreleased]
+
 ### Changed
 - Bump ADUtils requirements to 12+
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
 
-## [2.0.0] - 2024-03-04Z
+## [2.0.0] - 2024-03-04
 
 ### Changed
 - Bump ADUtils requirements to 12+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [2.0.0] - 2024-03-04Z
+
 ### Changed
 - Bump ADUtils requirements to 12+
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - ADNavigationBarExtension (1.0.4):
+  - ADNavigationBarExtension (2.0.0):
     - ADUtils (~> 12.0)
   - ADUtils (12.1.1):
     - ADUtils/objc (= 12.1.1)
@@ -23,7 +23,7 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  ADNavigationBarExtension: 7bb3042ea4375225682979774a787ec760a6e22f
+  ADNavigationBarExtension: 1be9d794fb7715b7d1bfa5158ddcabe176ffb769
   ADUtils: a3e9fdcfe76222dd3abfa4659ad1e8249ed16c95
   SwiftLint: 5ce4d6a8ff83f1b5fd5ad5dbf30965d35af65e44
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -83,7 +83,8 @@ def update_changelog(target_version)
   changelog_path = ENV["CHANGELOG"]
   stamp_changelog(
     changelog_path: changelog_path,
-    section_identifier: "#{target_version}"
+    section_identifier: "#{target_version}",
+    stamp_datetime_format: '%F'
   )
 
   git_add(path: changelog_path)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -101,9 +101,12 @@ def bump_podspec(target_version)
     version_number: target_version
   )
 
-  git_add(path: podspec_path)
+  pod_install # update the Podfile.lock with the new version
+
+  path = [podspec_path, "Podfile.lock"]
+  git_add(path: path)
   git_commit(
-    path: podspec_path,
+    path: path,
     message: "Bump to #{target_version}"
   )
 end


### PR DESCRIPTION
### Changed
- Bump ADUtils requirements to 12+

### Fix
- Fix safe area when setting the child VCs directly

### Removed
- Drop support of iOS 11, 12 and 13
- Remove workaround property `ad_isTranslucent`, use `UINavigationBar.appearance().isTranslucent` instead.
